### PR TITLE
feat: install dependencies on start

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+if [ "$NODE_ENV" != "production" ]; then
+	yarn install
+fi
+
+exec "$@"


### PR DESCRIPTION
A docker-entrypoint.sh script was added to automatically run yarn install upon starting a development container.

Resolves #113.