### PR TITLE
feat: make correspondent more personal

### DIFF
--- a/src/locales/de/eventInvitation.json
+++ b/src/locales/de/eventInvitation.json
@@ -13,5 +13,5 @@
     "eventVisibilityIsPublic": "öffentliche",
     "eventVisibility": "Dies ist eine {{eventVisibility}} Veranstaltung.",
     "header": "{{eventAuthorUsername}} hat dich eingeladen!",
-    "subject": "Einladung: {{eventName}} von {{eventAuthorUsername}}"
+    "subject": "Einladung: {{eventName}}"
 }

--- a/src/locales/en/eventInvitation.json
+++ b/src/locales/en/eventInvitation.json
@@ -13,5 +13,5 @@
     "eventVisibilityIsPublic": "a public",
     "eventVisibility": "This is {{eventVisibility}} event.",
     "header": "{{eventAuthorUsername}} invited you!",
-    "subject": "Invitation: {{eventName}} by {{eventAuthorUsername}}"
+    "subject": "Invitation: {{eventName}}"
 }

--- a/src/smtp.ts
+++ b/src/smtp.ts
@@ -253,6 +253,7 @@ export async function sendEventInvitationMail(
       try {
         sendMailTemplated(
           {
+            from: `"${event.authorUsername}" <noreply@maev.si>`,
             icalEvent: {
               content: res,
               filename: event.authorUsername + '_' + event.slug + '.ics',

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export interface DurationFormatOptions extends MomentFormatOptionsBase {
 }
 
 export interface Mail {
+  from?: string
   html?: string
   icalEvent?: Record<string, unknown> // https://nodemailer.com/message/calendar-events/
   subject?: string


### PR DESCRIPTION
Resolves #125

> the username or real name should come first

Authentic emails have the sender's name only in the "from" field, not in the subject, I believe. So this PR removes the name from the subject and instead uses the sender's name in the "from" field.

For real name implementation see https://github.com/maevsi/maevsi/issues/107.